### PR TITLE
Circleci cache is king

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.0
+version: 2.1
 orbs:
   win: circleci/windows@1.0.0
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,9 @@ jobs:
           command: pwd
       - restore_cache:
           keys:
-              - site-packages-v1-{{ .Branch }}-{{ checksum "requirements.txt" }}
-              - site-packages-v1-{{ .Branch }}-
-              - site-packages-v1-
+              - site-packages-v3-{{ .Branch }}-{{ checksum "requirements.txt" }}
+              - site-packages-v3-{{ .Branch }}-
+              - site-packages-v3-
       - run:
           name: Install Python Dependencies
           command: |
@@ -31,7 +31,7 @@ jobs:
       - save_cache:
           paths:
             - /usr/local/lib/python3.7/site-packages
-          key: site-packages-v1-{{ .Branch }}-{{ checksum "requirements.txt" }}
+          key: site-packages-v3-{{ .Branch }}-{{ checksum "requirements.txt" }}
   build-windows:
     executor: win/vs2019
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,9 @@ jobs:
           command: ls
       - restore_cache:
           keys:
-              - venv-v1-{{ .Branch }}-{{ checksum "requirements.txt" }}
-              - venv-v1-{{ .Branch }}-
-              - venv-v1-
+              - venv-v2-{{ .Branch }}-{{ checksum "requirements.txt" }}
+              - venv-v2-{{ .Branch }}-
+              - venv-v2-
       - run:
           name: Install Python Dependencies
           command: |
@@ -30,8 +30,8 @@ jobs:
           command: ls
       - save_cache:
           paths:
-            - venv
-          key: venv-v1-{{ .Branch }}-{{ checksum "requirements.txt" }}
+            - __pycache__
+          key: venv-v2-{{ .Branch }}-{{ checksum "requirements.txt" }}
   build-windows:
     executor: win/vs2019
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,9 @@ jobs:
       - checkout
       - restore_cache:
          keys:
-            - pip-packages-v1-{{ .Branch }}-{{ checksum "requirements.txt" }}
-            - pip-packages-v1-{{ .Branch }}-
-            - pip-packages-v1-
+            - site-packages-v1-{{ .Branch }}-{{ checksum "requirements.txt" }}
+            - site-packages-v1-{{ .Branch }}-
+            - site-packages-v1-
       - run:
          name: Install Python Dependencies
          command: |
@@ -24,9 +24,8 @@ jobs:
            flake8 . --exit-zero
       - save_cache:
          paths:
-           - ~/.local/share/virtualenvs/venv  # this path depends on where pipenv creates a virtualenv
            - ~/usr/local/lib/python3.7/site-packages
-         key: pip-packages-v1-{{ .Branch }}-{{ checksum "requirements.txt" }}
+         key: site-packages-v1-{{ .Branch }}-{{ checksum "requirements.txt" }}
   build-windows:
     executor: win/vs2019
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,25 +7,28 @@ jobs:
       - image: circleci/python:3.7.4
     steps:
       - checkout
+      - run:
+          name: Display directory
+          command: ls
       - restore_cache:
-         keys:
-            - site-packages-v2-{{ .Branch }}-{{ checksum "requirements.txt" }}
-            - site-packages-v2-{{ .Branch }}-
-            - site-packages-v2-
+          keys:
+              - venv-packages-v1-{{ .Branch }}-{{ checksum "requirements.txt" }}
+              - venv-packages-v1-{{ .Branch }}-
+              - venv-packages-v1-
       - run:
-         name: Install Python Dependencies
-         command: |
-           pip install --user --upgrade pip
-           pip install -r requirements.txt
+          name: Install Python Dependencies
+          command: |
+            pip install --user --upgrade pip
+            pip install -r requirements.txt
       - run:
-         name: Run Unit Tests
-         command: |
-           pytest --cov=src --cov=test
-           flake8 . --exit-zero
+          name: Run Unit Tests
+          command: |
+            pytest --cov=src --cov=test
+            flake8 . --exit-zero
       - save_cache:
-         paths:
-           - /usr/local/lib/python3.7/site-packages
-         key: site-packages-v2-{{ .Branch }}-{{ checksum "requirements.txt" }}
+          paths:
+            - venv
+          key: venv-v1-{{ .Branch }}-{{ checksum "requirements.txt" }}
   build-windows:
     executor: win/vs2019
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
       - save_cache:
          paths:
            - ~/.local/share/virtualenvs/venv  # this path depends on where pipenv creates a virtualenv
+           - ~/usr/local/lib/python3.7/site-packages
          key: pip-packages-v1-{{ .Branch }}-{{ checksum "requirements.txt" }}
   build-windows:
     executor: win/vs2019

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,12 +9,9 @@ jobs:
       - checkout
       - restore_cache:
          keys:
-            - pip-packages-v1-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+            - pip-packages-v1-{{ .Branch }}-{{ checksum "requirements.txt" }}
             - pip-packages-v1-{{ .Branch }}-
             - pip-packages-v1-
-      - run:
-         name: Locate site Packages
-         command: python -c "import site; print(site.getsitepackages())"
       - run:
          name: Install Python Dependencies
          command: |
@@ -28,7 +25,7 @@ jobs:
       - save_cache:
          paths:
            - ~/.local/share/virtualenvs/venv  # this path depends on where pipenv creates a virtualenv
-         key: pip-packages-v1-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+         key: pip-packages-v1-{{ .Branch }}-{{ checksum "requirements.txt" }}
   build-windows:
     executor: win/vs2019
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,9 @@ jobs:
           command: ls
       - restore_cache:
           keys:
-              - venv-packages-v1-{{ .Branch }}-{{ checksum "requirements.txt" }}
-              - venv-packages-v1-{{ .Branch }}-
-              - venv-packages-v1-
+              - venv-v1-{{ .Branch }}-{{ checksum "requirements.txt" }}
+              - venv-v1-{{ .Branch }}-
+              - venv-v1-
       - run:
           name: Install Python Dependencies
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,9 @@ jobs:
       - checkout
       - restore_cache:
          keys:
-            - site-packages-v1-{{ .Branch }}-{{ checksum "requirements.txt" }}
-            - site-packages-v1-{{ .Branch }}-
-            - site-packages-v1-
+            - site-packages-v2-{{ .Branch }}-{{ checksum "requirements.txt" }}
+            - site-packages-v2-{{ .Branch }}-
+            - site-packages-v2-
       - run:
          name: Install Python Dependencies
          command: |
@@ -24,8 +24,8 @@ jobs:
            flake8 . --exit-zero
       - save_cache:
          paths:
-           - ~/usr/local/lib/python3.7/site-packages
-         key: site-packages-v1-{{ .Branch }}-{{ checksum "requirements.txt" }}
+           - /usr/local/lib/python3.7/site-packages
+         key: site-packages-v2-{{ .Branch }}-{{ checksum "requirements.txt" }}
   build-windows:
     executor: win/vs2019
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,3 +47,4 @@ workflows:
   build-test:
     jobs:
       - build-linux
+      - build-windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,11 +7,13 @@ jobs:
       - image: circleci/python:3.7.4
     steps:
       - checkout
+      - run: sudo chown -R circleci:circleci /usr/local/bin
+      - run: sudo chown -R circleci:circleci /usr/local/lib/python3.7/site-packages
       - restore_cache:
           keys:
-              - site-packages-v3-{{ .Branch }}-{{ checksum "requirements.txt" }}
-              - site-packages-v3-{{ .Branch }}-
-              - site-packages-v3-
+              - deps9-{{ .Branch }}-{{ checksum "requirements.txt" }}
+              - deps9-{{ .Branch }}-
+              - deps9-
       - run:
           name: Install Python Dependencies
           command: |
@@ -24,8 +26,10 @@ jobs:
             flake8 . --exit-zero
       - save_cache:
           paths:
-            - /usr/local/lib/python3.7/site-packages
-          key: site-packages-v3-{{ .Branch }}-{{ checksum "requirements.txt" }}
+            - ".venv"
+            - "/usr/local/bin"
+            - "/usr/local/lib/python3.7/site-packages"
+          key: deps9-{{ .Branch }}-{{ checksum "requirements.txt" }}
   build-windows:
     executor: win/vs2019
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,6 @@ jobs:
       - image: circleci/python:3.7.4
     steps:
       - checkout
-      - run:
-          name: Display directory
-          command: pwd
       - restore_cache:
           keys:
               - site-packages-v3-{{ .Branch }}-{{ checksum "requirements.txt" }}
@@ -25,9 +22,6 @@ jobs:
           command: |
             pytest --cov=src --cov=test
             flake8 . --exit-zero
-      - run:
-          name: Display directory again
-          command: pwd
       - save_cache:
           paths:
             - /usr/local/lib/python3.7/site-packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,12 +9,12 @@ jobs:
       - checkout
       - run:
           name: Display directory
-          command: ls
+          command: pwd
       - restore_cache:
           keys:
-              - venv-v2-{{ .Branch }}-{{ checksum "requirements.txt" }}
-              - venv-v2-{{ .Branch }}-
-              - venv-v2-
+              - site-packages-v1-{{ .Branch }}-{{ checksum "requirements.txt" }}
+              - site-packages-v1-{{ .Branch }}-
+              - site-packages-v1-
       - run:
           name: Install Python Dependencies
           command: |
@@ -27,11 +27,11 @@ jobs:
             flake8 . --exit-zero
       - run:
           name: Display directory again
-          command: ls
+          command: pwd
       - save_cache:
           paths:
-            - __pycache__
-          key: venv-v2-{{ .Branch }}-{{ checksum "requirements.txt" }}
+            - /usr/local/lib/python3.7/site-packages
+          key: site-packages-v1-{{ .Branch }}-{{ checksum "requirements.txt" }}
   build-windows:
     executor: win/vs2019
     steps:
@@ -49,4 +49,3 @@ workflows:
   build-test:
     jobs:
       - build-linux
-      - build-windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,9 @@ jobs:
           command: |
             pytest --cov=src --cov=test
             flake8 . --exit-zero
+      - run:
+          name: Display directory again
+          command: ls
       - save_cache:
           paths:
             - venv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,14 @@ jobs:
       - image: circleci/python:3.7.4
     steps:
       - checkout
+      - restore_cache:
+         keys:
+            - pip-packages-v1-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+            - pip-packages-v1-{{ .Branch }}-
+            - pip-packages-v1-
+      - run:
+         name: Locate site Packages
+         command: python -c "import site; print(site.getsitepackages())"
       - run:
          name: Install Python Dependencies
          command: |
@@ -17,6 +25,10 @@ jobs:
          command: |
            pytest --cov=src --cov=test
            flake8 . --exit-zero
+      - save_cache:
+         paths:
+           - ~/.local/share/virtualenvs/venv  # this path depends on where pipenv creates a virtualenv
+         key: pip-packages-v1-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
   build-windows:
     executor: win/vs2019
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.1
+version: 2.0
 orbs:
   win: circleci/windows@1.0.0
 jobs:


### PR DESCRIPTION
cache dependencies: https://circleci.com/docs/2.0/language-python/#cache-dependencies. From 15+ seconds for installing python dependencies to 1 second (nothing to install) and 4+ seconds for restoring cache. Should trigger on change in requirements.txt and Branch (e.g. after merge), not tested.